### PR TITLE
Fix rate limiting by reusing global session cookies

### DIFF
--- a/Plugins/SiriusXM/Bin/sxm.pl
+++ b/Plugins/SiriusXM/Bin/sxm.pl
@@ -403,17 +403,16 @@ sub new {
 # Get or create cookie jar for a specific channel
 sub get_channel_cookie_jar {
     my ($self, $channel_id) = @_;
-    
-    # If no channel_id specified, use global cookie jar for backward compatibility
-    return $self->{ua}->cookie_jar unless $channel_id;
-    
-    # Create channel-specific cookie jar if it doesn't exist
-    if (!exists $self->{channel_cookies}->{$channel_id}) {
-        $self->{channel_cookies}->{$channel_id} = HTTP::Cookies->new;
-        main::log_debug("Created new cookie jar for channel: $channel_id");
-    }
-    
-    return $self->{channel_cookies}->{$channel_id};
+
+    # Always reuse the global cookie jar for all channels.
+    # Per-channel cookie jars start empty, forcing a separate login call
+    # for each channel playback request. Rapid back-to-back logins to the
+    # SiriusXM API trigger server-side rate limiting (HTTP 500), which
+    # prevents both channel listing and stream playback from working.
+    # Sharing the global session avoids redundant authentication while
+    # still allowing the existing session-expiry/re-auth logic to handle
+    # token refreshes when needed.
+    return $self->{ua}->cookie_jar;
 }
 
 # Set the user agent to use a specific channel's cookie jar


### PR DESCRIPTION
## Summary

- Per-channel cookie jars start empty, forcing a separate `modify/authentication` login call for each channel playback request
- Rapid back-to-back logins trigger SiriusXM API rate limiting (HTTP 500), breaking both channel listing and stream playback
- Fix: `get_channel_cookie_jar()` now always returns the global cookie jar so all channels share the single authenticated session from proxy startup

## Problem

When a user browses SiriusXM channels and plays one, the proxy makes two login calls in quick succession (one global at startup, one per-channel for playback). SiriusXM's API returns 500 on the second call, and the proxy fails to serve the stream. Repeated restart attempts compound the rate limiting, sometimes blocking logins for several minutes.

## Solution

Reuse the global cookie jar for all channel requests instead of creating isolated per-channel jars. The existing session-expiry and re-auth logic (codes 201/208) continues to handle token refreshes.

## Test plan

- [x] Proxy starts and authenticates once globally
- [x] Channel listing loads without additional login calls
- [x] Channel playback works without triggering rate limits
- [x] Tested with live SiriusXM subscription streaming multiple channels